### PR TITLE
feat: export config writing

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
     "LICENSE"
   ],
   "main": "dist/index.js",
+  "exports": {
+    "./lib": {
+      "types": "./dist/lib/index.d.ts",
+      "import": "./dist/lib/index.js"
+    }
+  },
   "bin": {
     "connect-mcp-server": "dist/proxy.js",
     "connect-mcp-server-client": "dist/client.js"
@@ -54,7 +60,8 @@
   "tsup": {
     "entry": [
       "src/client.ts",
-      "src/proxy.ts"
+      "src/proxy.ts",
+      "src/lib/index.ts"
     ],
     "format": [
       "esm"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,2 @@
+export { writeJsonFile } from './mcp-auth-config'
+export { getServerUrlHash } from './utils'

--- a/src/lib/mcp-auth-config.ts
+++ b/src/lib/mcp-auth-config.ts
@@ -84,7 +84,7 @@ export async function deleteLockfile(serverUrlHash: string): Promise<void> {
 export function getConfigDir(): string {
   const baseConfigDir = process.env.MCP_REMOTE_CONFIG_DIR || path.join(os.homedir(), '.mcp-auth')
   // Add a version subdirectory so we don't need to worry about backwards/forwards compatibility yet
-  return path.join(baseConfigDir, `mcp-remote-${MCP_REMOTE_VERSION}`)
+  return path.join(baseConfigDir, `glean-connect-mcp-server-${MCP_REMOTE_VERSION}`)
 }
 
 /**


### PR DESCRIPTION
We're going to write tokens and client information where mcp-remote is expecting to find it, after having done our device flow auth.

To make it easier to write to the correct location, patch mcp-remote s that the utilities for computing the file locations is exported.


The specific path is also changed from `$HOME/.mcp-auth/mcp-remote-${version}/...` to `$HOME/.mcp-auth/glean-connect-mcp-server-${version}` to avoid confusion, since users are likely using `mcp-remote` for other MCP servers.