### PR TITLE
feat: export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "./lib": {
       "types": "./dist/lib/index.d.ts",
       "import": "./dist/lib/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "bin": {
     "connect-mcp-server": "dist/proxy.js",


### PR DESCRIPTION
Allow consumers to import via

```ts
import connectMcpPackageJson from '@gleanwork/connect-mcp-server/package.json' with { type: 'json' };
```

Useful for e.g. checking the exact version of @gleanwork/connect-mcp-server being used.
